### PR TITLE
Update testing to work w/ stactools v0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
     = src
 packages = find_namespace:
 install_requires =
-    stactools ~= 0.1
+    stactools ~= 0.2.1a0
     boto3 ~= 1.17
 
 [options.packages.find]

--- a/src/stactools/threedep/metadata.py
+++ b/src/stactools/threedep/metadata.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import datetime
 from typing import Union, Optional
 from xml.etree import ElementTree
@@ -17,10 +16,10 @@ from stactools.threedep import utils
 class Metadata:
     """3DEP file metadata."""
     @classmethod
-    def from_href(
-            cls,
-            href: str,
-            read_href_modifier: Optional[ReadHrefModifier] = None) -> Metadata:
+    def from_href(cls,
+                  href: str,
+                  read_href_modifier: Optional[ReadHrefModifier] = None
+                  ) -> "Metadata":
         """Creates a metadata from an href to the XML metadata file."""
         text = io.read_text(href, read_href_modifier)
         element_tree = ElementTree.fromstring(text)
@@ -30,7 +29,7 @@ class Metadata:
     def from_product_and_id(cls,
                             product: str,
                             id: str,
-                            base: str = None) -> Metadata:
+                            base: str = None) -> "Metadata":
         """Creates a Metadata from a product and id."""
         if base is None:
             base = DEFAULT_BASE
@@ -85,7 +84,7 @@ class Metadata:
                               mapping(box(*original_bbox)))
 
     @property
-    def datetime(self) -> Union[datetime.datetime, None]:
+    def datetime(self) -> Union["datetime.datetime", None]:
         """Returns the collection publication datetime."""
         if self.current == "publication date":
             return _format_date(self.pubdate)
@@ -93,7 +92,7 @@ class Metadata:
             raise NotImplementedError
 
     @property
-    def start_datetime(self) -> Union[datetime.datetime, None]:
+    def start_datetime(self) -> Union["datetime.datetime", None]:
         """Returns the start datetime for this record.
 
         This can be a while ago, since the national elevation dataset was
@@ -102,7 +101,7 @@ class Metadata:
         return _format_date(self.begdate)
 
     @property
-    def end_datetime(self) -> Union[datetime.datetime, None]:
+    def end_datetime(self) -> Union["datetime.datetime", None]:
         """Returns the end datetime for this record."""
         return _format_date(self.enddate, end_of_year=True)
 
@@ -203,8 +202,9 @@ class Metadata:
                           id_only=id_only)
 
 
-def _format_date(date: str,
-                 end_of_year: bool = False) -> Union[datetime.datetime, None]:
+def _format_date(
+        date: str,
+        end_of_year: bool = False) -> Union["datetime.datetime", None]:
     if len(date) == 4:
         year = int(date)
         if end_of_year:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from stactools.testing import TestData
+
+test_data = TestData(__file__)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,9 @@ from tempfile import TemporaryDirectory
 import pystac
 
 from stactools.threedep.commands import create_threedep_command
-from tests.utils import CliTestCase, TestData
+from stactools.testing import CliTestCase
+
+from tests import test_data
 
 
 class CreateCollectionTest(CliTestCase):
@@ -12,7 +14,7 @@ class CreateCollectionTest(CliTestCase):
         return [create_threedep_command]
 
     def test_create_collection(self):
-        path = TestData.get_path("data-files/threedep/base")
+        path = test_data.get_path("data-files/base")
         with TemporaryDirectory() as directory:
             result = self.run_command([
                 "threedep", "create-catalog", directory, "--id", "n41w106",

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,15 +1,16 @@
 import datetime
 import unittest
 
-from tests.utils import TestData
 from stactools.threedep import stac
 from stactools.threedep.constants import USGS_FTP_BASE
+
+from tests import test_data
 
 
 class CreateItemTest(unittest.TestCase):
     def test_create_item_1(self):
-        path = TestData.get_path(
-            "data-files/threedep/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
+        path = test_data.get_path(
+            "data-files/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
         item = stac.create_item(path)
         self.assertEqual(item.id, "n41w106-1")
         self.assertTrue(item.geometry is not None)
@@ -104,8 +105,7 @@ class CreateItemTest(unittest.TestCase):
         item.validate()
 
     def test_create_item_1_weird_date(self):
-        path = TestData.get_path(
-            "data-files/threedep/one-offs/USGS_1_n19w090.xml")
+        path = test_data.get_path("data-files/one-offs/USGS_1_n19w090.xml")
         item = stac.create_item(path)
         self.assertEqual(
             item.datetime,
@@ -118,15 +118,15 @@ class CreateItemTest(unittest.TestCase):
                               tzinfo=datetime.timezone.utc))
 
     def test_create_item_13(self):
-        path = TestData.get_path(
-            "data-files/threedep/base/13/TIFF/n41w106/USGS_13_n41w106.xml")
+        path = test_data.get_path(
+            "data-files/base/13/TIFF/n41w106/USGS_13_n41w106.xml")
         item = stac.create_item(path)
         self.assertEqual(item.id, "n41w106-13")
         self.assertEqual(item.common_metadata.gsd, 10)
 
     def test_create_item_with_base(self):
-        path = TestData.get_path(
-            "data-files/threedep/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
+        path = test_data.get_path(
+            "data-files/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
         item = stac.create_item(path, base=USGS_FTP_BASE)
         data = item.assets["data"]
         self.assertEqual(
@@ -149,7 +149,7 @@ class CreateItemTest(unittest.TestCase):
              "/Elevation/1/TIFF/n41w106/USGS_1_n41w106.xml"))
 
     def test_create_item_from_product_and_id(self):
-        path = TestData.get_path("data-files/threedep/base")
+        path = test_data.get_path("data-files/base")
         item = stac.create_item_from_product_and_id("1", "n41w106", path)
         item.validate()
 
@@ -161,14 +161,14 @@ class CreateItemTest(unittest.TestCase):
             did_it = True
             return href
 
-        path = TestData.get_path(
-            "data-files/threedep/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
+        path = test_data.get_path(
+            "data-files/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
         _ = stac.create_item(path, modify_href)
         self.assertTrue(did_it)
 
     def test_explicit_none_goes_to_aws(self):
-        path = TestData.get_path(
-            "data-files/threedep/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
+        path = test_data.get_path(
+            "data-files/base/1/TIFF/n41w106/USGS_1_n41w106.xml")
         item0 = stac.create_item(path)
         item1 = stac.create_item(path, base=None)
         self.assertEqual(item0.to_dict(), item1.to_dict())


### PR DESCRIPTION
Steps:
- Add a `stactools.testing.TestData` instantiation in `tests/__init__.py`
- Switch from using `TestData.get_path` to `tests.test_data.get_path`
- Update data paths to remove the package name

Also includes some typing fixes that were broken on Python 3.6, but weren't caught previously b/c we weren't testing Python 3.6 in stactools v0.1.