### PR TITLE
Fix issue with `asset_ids` in `create-catalog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - pre-commit, black, mypy, and more ([#11](https://github.com/stactools-packages/threedep/pull/11))
 - Raster and scientific extensions, package description ([#12](https://github.com/stactools-packages/threedep/pull/12))
+- Fix `asset_ids` definition in create-catalog CLI ([#14](https://github.com/stactools-packages/threedep/issues/14))
 
 ### Deprecated
 

--- a/src/stactools/threedep/commands.py
+++ b/src/stactools/threedep/commands.py
@@ -61,9 +61,7 @@ def create_threedep_command(cli: Group) -> Command:
         collections = {}
         items = defaultdict(list)
         for product in PRODUCTS:
-            if not asset_ids:
-                asset_ids = utils.fetch_ids(product)
-            for asset_id in asset_ids:
+            for asset_id in asset_ids or utils.fetch_ids(product):
                 item = stac.create_item_from_product_and_id(
                     product, asset_id, base=source
                 )


### PR DESCRIPTION
**Related Issue(s):**
Resolves #14 

**Description:**
Rather than overwriting `asset_ids` variable when running the first collection, conditionally loop through `asset_ids` or `utils.fetch_ids(product)` to make sure you are not running `asset_ids` from one product on the other!

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [ ] Code lints properly (run `scripts/lint`).
  - this is failing due to a typing issue in `stactools.core`, I think?
  
  ```
  $ scripts/lint
    mypy.....................................................................Failed
    - hook id: mypy
    - exit code: 1
    
    tests/test_commands.py:14: error: Class cannot subclass "CliTestCase" (has type "Any")  [misc]
    Found 1 error in 1 file (checked 10 source files)
  ``` 
- [x] Tests pass (run `scripts/test`).
  * `pytest` is passing, but not the linter that runs before it
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
